### PR TITLE
Update shigure.yml

### DIFF
--- a/ansible/group_vars/shigure/shigure.yml
+++ b/ansible/group_vars/shigure/shigure.yml
@@ -1,6 +1,6 @@
 server_group: "shigure"
 
-samba_interfaces: "192.168.77.0/24 192.168.101.71/24"
+samba_interfaces: "192.168.0.0/24 192.168.101.71/24"
 
 spin_out_hdd_list:
   - { name: /dev/sda }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Updated the `samba_interfaces` configuration in the `shigure.yml` file to use the correct network subnet `192.168.0.0/24` instead of the previous `192.168.77.0/24`.

- This change ensures that the Samba server is configured to listen on the correct network interface, allowing clients to properly access shared resources.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shigure.yml</strong><dd><code>Update Samba network interface configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ansible/group_vars/shigure/shigure.yml

<li>Updated <code>samba_interfaces</code> to use the correct network subnet <br><code>192.168.0.0/24</code>


</details>


  </td>
  <td><a href="https://github.com/toshibe678/infra/pull/33/files#diff-6dd5391ec6ee3d5064e60780079b2f14c6ab297736b6271737fa47e07ce161cd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>